### PR TITLE
Add last scheduled

### DIFF
--- a/observation_portal/observations/tests.py
+++ b/observation_portal/observations/tests.py
@@ -15,8 +15,8 @@ from observation_portal.observations.models import Observation, ConfigurationSta
 from observation_portal.proposals.models import Proposal, Membership, Semester
 from observation_portal.accounts.models import Profile
 from observation_portal.common.test_helpers import create_simple_requestgroup, create_simple_configuration
-from observation_portal.requestgroups import views
-from observation_portal.requestgroups import viewsets
+from observation_portal.observations import views
+from observation_portal.observations import viewsets
 import observation_portal.observations.signals.handlers  # noqa
 
 from unittest.mock import patch

--- a/observation_portal/observations/tests.py
+++ b/observation_portal/observations/tests.py
@@ -6,15 +6,20 @@ from django.contrib.auth.models import User
 from datetime import datetime
 from dateutil.parser import parse
 from django.urls import reverse
+from django.core import cache
+from dateutil.parser import parse as datetime_parser
+from datetime import timedelta
 
 from observation_portal.requestgroups.models import RequestGroup, Window, Location
 from observation_portal.observations.models import Observation, ConfigurationStatus, Summary
 from observation_portal.proposals.models import Proposal, Membership, Semester
 from observation_portal.accounts.models import Profile
 from observation_portal.common.test_helpers import create_simple_requestgroup, create_simple_configuration
+from observation_portal.requestgroups import views
+from observation_portal.requestgroups import viewsets
 import observation_portal.observations.signals.handlers  # noqa
 
-
+from unittest.mock import patch
 import copy
 
 observation = {
@@ -886,3 +891,63 @@ class TestUpdateConfigurationStatusApi(TestObservationApiBase):
         self.assertEqual(request.state, 'PENDING')
         self.requestgroup.refresh_from_db()
         self.assertEqual(self.requestgroup.state, 'PENDING')
+
+
+class TestLastScheduled(TestObservationApiBase):
+    def setUp(self):
+        super().setUp()
+        # Mock the cache with a real one for these tests
+        self.locmem_cache = cache._create_cache('django.core.cache.backends.locmem.LocMemCache')
+        self.locmem_cache.clear()
+        self.patch1 = patch.object(views, 'cache', self.locmem_cache)
+        self.patch1.start()
+        self.patch2 = patch.object(viewsets, 'cache', self.locmem_cache)
+        self.patch2.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self.patch1.stop()
+        self.patch2.stop()
+
+    def test_last_schedule_date_is_7_days_out_if_no_cached_value(self):
+        last_schedule_cached = self.locmem_cache.get('observation_portal_last_schedule_time')
+        self.assertIsNone(last_schedule_cached)
+
+        response = self.client.get(reverse('api:last_scheduled'))
+        last_schedule = response.json()['last_schedule_time']
+        self.assertAlmostEqual(datetime_parser(last_schedule), timezone.now() - timedelta(days=7),
+                               delta=timedelta(minutes=1))
+
+    def test_last_schedule_date_is_updated_when_single_observation_is_submitted(self):
+        last_schedule_cached = self.locmem_cache.get('observation_portal_last_schedule_time')
+        self.assertIsNone(last_schedule_cached)
+        observation = self._generate_observation_data(
+            self.requestgroup.requests.first().id, [self.requestgroup.requests.first().configurations.first().id]
+        )
+        self._create_observation(observation)
+
+        response = self.client.get(reverse('api:last_scheduled'))
+        last_schedule = response.json()['last_schedule_time']
+        self.assertAlmostEqual(datetime_parser(last_schedule), timezone.now(), delta=timedelta(minutes=1))
+
+    def test_last_schedule_date_is_updated_when_multiple_observations_are_submitted(self):
+        last_schedule_cached = self.locmem_cache.get('observation_portal_last_schedule_time')
+        self.assertIsNone(last_schedule_cached)
+        observation = self._generate_observation_data(
+            self.requestgroup.requests.first().id, [self.requestgroup.requests.first().configurations.first().id]
+        )
+        observations = [observation, observation, observation]
+        self._create_observation(observations)
+
+        response = self.client.get(reverse('api:last_scheduled'))
+        last_schedule = response.json()['last_schedule_time']
+        self.assertAlmostEqual(datetime_parser(last_schedule), timezone.now(), delta=timedelta(minutes=1))
+
+    def test_last_schedule_date_is_not_updated_when_observation_is_mixed(self):
+        mixer.blend(Observation, request=self.requestgroup.requests.first())
+        last_schedule_cached = self.locmem_cache.get('observation_portal_last_schedule_time')
+        self.assertIsNone(last_schedule_cached)
+        response = self.client.get(reverse('api:last_scheduled'))
+        last_schedule = response.json()['last_schedule_time']
+        self.assertAlmostEqual(datetime_parser(last_schedule), timezone.now() - timedelta(days=7),
+                               delta=timedelta(minutes=1))

--- a/observation_portal/observations/views.py
+++ b/observation_portal/observations/views.py
@@ -1,5 +1,11 @@
 from django_filters.views import FilterView
 from django.views.generic import DetailView
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAdminUser
+from django.core.cache import cache
+from django.utils import timezone
+from rest_framework.response import Response
+from datetime import timedelta
 
 from observation_portal.observations.models import Observation
 from observation_portal.common.mixins import StaffRequiredMixin
@@ -16,3 +22,14 @@ class ObservationListView(StaffRequiredMixin, FilterView):
     paginate_by = 50
     ordering = '-modified'
     template_name = 'observations/observation_list.html'
+
+
+class LastScheduledView(APIView):
+    '''
+        Returns the datetime of the last status of requests change or new requests addition
+    '''
+    permission_classes = (IsAdminUser,)
+
+    def get(self, request):
+        last_schedule_time = cache.get('observation_portal_last_schedule_time', timezone.now() - timedelta(days=7))
+        return Response({'last_schedule_time': last_schedule_time})

--- a/observation_portal/observations/views.py
+++ b/observation_portal/observations/views.py
@@ -25,9 +25,13 @@ class ObservationListView(StaffRequiredMixin, FilterView):
 
 
 class LastScheduledView(APIView):
-    '''
-        Returns the datetime of the last status of requests change or new requests addition
-    '''
+    """
+        Returns the datetime of the last time new observations were submitted. This endpoint is expected to be polled
+        frequently (~every 5 seconds) to for a client to decide if it needs to pull down the schedule or not.
+
+        We are only updating when observations are submitted, and not when they are cancelled, because a site should
+        not really care if the only change was removing things from it's schedule.
+    """
     permission_classes = (IsAdminUser,)
 
     def get(self, request):

--- a/observation_portal/observations/views.py
+++ b/observation_portal/observations/views.py
@@ -35,5 +35,9 @@ class LastScheduledView(APIView):
     permission_classes = (IsAdminUser,)
 
     def get(self, request):
-        last_schedule_time = cache.get('observation_portal_last_schedule_time', timezone.now() - timedelta(days=7))
+        site = request.query_params.get('site')
+        cache_key = 'observation_portal_last_schedule_time'
+        if site:
+            cache_key += f"_{site}"
+        last_schedule_time = cache.get(cache_key, timezone.now() - timedelta(days=7))
         return Response({'last_schedule_time': last_schedule_time})

--- a/observation_portal/observations/viewsets.py
+++ b/observation_portal/observations/viewsets.py
@@ -95,10 +95,12 @@ class ObservationViewSet(CreateListModelMixin, ListAsDictMixin, viewsets.ModelVi
         ''' This overrides the create mixin create method, but does the same thing minus the serializing of the
             data into the response at the end
         '''
+        cache_key = 'observation_portal_last_schedule_time'
         if not isinstance(request.data, list):
             # Just do the default create for the single block case
             created_obs = super().create(request, args, kwargs)
-            cache.set('observation_portal_last_schedule_time', timezone.now(), None)
+            site = request.data['site']
+            cache.set(cache_key + f"_{site}", timezone.now(), None)
             return created_obs
         else:
             serializer = self.get_serializer(data=request.data)
@@ -118,7 +120,8 @@ class ObservationViewSet(CreateListModelMixin, ListAsDictMixin, viewsets.ModelVi
                             observations.append(individual_serializer.save())
                         else:
                             errors[i] = individual_serializer.error
-            cache.set('observation_portal_last_schedule_time', timezone.now(), None)
+            site = request.data[0]['site']
+            cache.set(cache_key + f"_{site}", timezone.now(), None)
             return Response({'num_created': len(observations),
                                  'errors': errors}, status=201)
 

--- a/observation_portal/urls.py
+++ b/observation_portal/urls.py
@@ -31,6 +31,7 @@ from observation_portal.requestgroups.views import InstrumentsInformationView, O
 from observation_portal.requestgroups.views import ContentionView, PressureView
 from observation_portal.accounts.views import ProfileApiView
 from observation_portal.proposals.viewsets import ProposalViewSet, SemesterViewSet
+from observation_portal.observations.views import LastScheduledView
 from observation_portal.observations.viewsets import ObservationViewSet, ScheduleViewSet, ConfigurationStatusViewSet
 import observation_portal.sciapplications.urls as sciapplications_urls
 import observation_portal.requestgroups.urls as requestgroup_urls
@@ -59,7 +60,8 @@ api_urlpatterns = ([
     url(r'instruments/', InstrumentsInformationView.as_view(), name='instruments_information'),
     url(r'contention/(?P<instrument_name>.+)/', ContentionView.as_view(), name='contention'),
     url(r'pressure/', PressureView.as_view(), name='pressure'),
-    url(r'last_changed/', ObservationPortalLastChangedView.as_view(), name='last_changed')
+    url(r'last_changed/', ObservationPortalLastChangedView.as_view(), name='last_changed'),
+    url(r'last_scheduled/', LastScheduledView.as_view(), name='last_scheduled')
 ], 'api')
 
 schema_view = get_schema_view(
@@ -91,4 +93,3 @@ urlpatterns = [
 if settings.DEBUG:
     urlpatterns += staticfiles_urlpatterns()
     static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-


### PR DESCRIPTION
I've only updated the last_scheduled time on new observation submission right now, but we could consider updating it on observation cancellation as well. The issue of doing that is that we might trigger a telescope to update after cancellations but before new submissions at a site, but this would be a rare occurrence since they are submitted one after another.