### PR TITLE
Increase rapid response lifetime to 24 hours

### DIFF
--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -640,7 +640,7 @@ class RequestGroupSerializer(serializers.ModelSerializer):
                 elif data['observation_type'] == RequestGroup.RAPID_RESPONSE:
                     time_available = time_allocation.rr_allocation - time_allocation.rr_time_used
                     # For Rapid Response observations, check if the end time of the window is within
-                    # six hours + the duration of the observation
+                    # 24 hours + the duration of the observation
                     for request in data['requests']:
                         windows = request.get('windows')
                         for window in windows:
@@ -648,9 +648,12 @@ class RequestGroupSerializer(serializers.ModelSerializer):
                                 raise serializers.ValidationError(
                                     _("The Rapid Response observation window start time cannot be in the future.")
                                 )
-                            if window.get('end') - timezone.now() > timedelta(seconds=(duration + 21600)):
+                            if window.get('end') - timezone.now() > timedelta(seconds=(duration + 86400)):
                                 raise serializers.ValidationError(
-                                    _("The Rapid Response observation window must be within the next six hours.")
+                                    _(
+                                        "A Rapid Response observation must start within the next 24 hours, so the "
+                                        "window end time must be within the next (24 hours + the observation duration)"
+                                    )
                                 )
                 elif data['observation_type'] == RequestGroup.TIME_CRITICAL:
                     # Time critical time

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -233,22 +233,22 @@ class TestUserPostRequestApi(SetTimeMixin, APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('cannot be in the future.', str(response.content))
 
-    def test_post_requestgroup_rr_within_six_hours(self):
+    def test_post_requestgroup_rr_within_24_hours(self):
         data = self.generic_payload.copy()
         data['observation_type'] = RequestGroup.RAPID_RESPONSE
         data['requests'][0]['windows'][0]['start'] = timezone.now() + timedelta(0)
-        data['requests'][0]['windows'][0]['end'] = timezone.now() + timedelta(0, 18000)
+        data['requests'][0]['windows'][0]['end'] = timezone.now() + timedelta(0, 82800)  # 23 hours
         response = self.client.post(reverse('api:request_groups-list'), data=data)
         self.assertEqual(response.status_code, 201)
 
-    def test_post_requestgroup_rr_not_within_six_hours(self):
+    def test_post_requestgroup_rr_not_within_24_hours(self):
         bad_data = self.generic_payload.copy()
         bad_data['observation_type'] = RequestGroup.RAPID_RESPONSE
         bad_data['requests'][0]['windows'][0]['start'] = timezone.now() + timedelta(0)
-        bad_data['requests'][0]['windows'][0]['end'] = timezone.now() + timedelta(0, 25200)
+        bad_data['requests'][0]['windows'][0]['end'] = timezone.now() + timedelta(0, 90000)  # 25 hours
         response = self.client.post(reverse('api:request_groups-list'), data=bad_data)
         self.assertEqual(response.status_code, 400)
-        self.assertIn('must be within the next six hours.', str(response.content))
+        self.assertIn('must start within the next 24 hours', str(response.content))
 
     def test_post_requestgroup_not_have_any_time_left(self):
         bad_data = self.generic_payload.copy()

--- a/static/js/components/requestgroup.vue
+++ b/static/js/components/requestgroup.vue
@@ -255,7 +255,7 @@
             for (var windowIndex = 0; windowIndex < this.requestgroup.requests[index].windows.length; ++windowIndex) {
               if (value === 'RAPID_RESPONSE') {
                 delete this.requestgroup.requests[index].windows[windowIndex].start;
-                this.requestgroup.requests[index].windows[windowIndex].end = moment.utc().add(6, 'hours').format(datetimeFormat);
+                this.requestgroup.requests[index].windows[windowIndex].end = moment.utc().add(24, 'hours').format(datetimeFormat);
               } else {
                 if (!('start' in this.requestgroup.requests[index].windows[windowIndex])) {
                   this.requestgroup.requests[index].windows[windowIndex].start = moment.utc().format(datetimeFormat);

--- a/static/js/components/util/customdatetime.vue
+++ b/static/js/components/util/customdatetime.vue
@@ -22,7 +22,7 @@
         </sup>
       </template>
       <VueCtkDateTimePicker 
-        v-model="theValue"
+        v-model="value"
         label=""
         :format="datetimeFormat"
         :formatted="datetimeFormat"
@@ -70,8 +70,7 @@
     data: function() {
       return {
         tooltipConfig: tooltipConfig,
-        datetimeFormat: datetimeFormat,
-        theValue: this.value
+        datetimeFormat: datetimeFormat
       }
     },
     computed: {


### PR DESCRIPTION
Rapid response observation window end times were limited to be within the next 6 hours in the future, this PR increases that limit to be within 24 hours in the future.