### PR TITLE
remove validation for configuration parameters in direct submissions,…

### DIFF
--- a/observation_portal/observations/serializers.py
+++ b/observation_portal/observations/serializers.py
@@ -85,7 +85,10 @@ class ObservationConfigurationSerializer(ConfigurationSerializer):
         return value
 
     def validate(self, data):
-        validated_data = super().validate(data)
+        # Currently don't validate configuration params for direct submissions until we add unschedulable flag to 
+        # generic modes in configdb
+        # validated_data = super().validate(data)
+        validated_data = data
         if validated_data['type'] not in ['BIAS', 'DARK', 'SKY_FLAT']:
             target_serializer = TargetSerializer(data=validated_data['target'])
             if not target_serializer.is_valid():

--- a/observation_portal/observations/serializers.py
+++ b/observation_portal/observations/serializers.py
@@ -85,7 +85,7 @@ class ObservationConfigurationSerializer(ConfigurationSerializer):
         return value
 
     def validate(self, data):
-        # Currently don't validate configuration params for direct submissions until we add unschedulable flag to 
+        # Currently don't validate configuration params for direct submissions until we add unschedulable flag to
         # generic modes in configdb
         # validated_data = super().validate(data)
         validated_data = data

--- a/observation_portal/observations/tests.py
+++ b/observation_portal/observations/tests.py
@@ -267,6 +267,17 @@ class TestPostScheduleApi(SetTimeMixin, APITestCase):
             obs_json['request']['configurations'][0]['guide_camera_name']
         )
 
+    def test_post_observation_hour_angle_missing_required_fields(self):
+        bad_observation = copy.deepcopy(self.observation)
+        bad_observation['request']['configurations'][0]['target']['type'] = 'HOUR_ANGLE'
+        bad_observation['request']['configurations'][0]['target']['ha'] = 9.45
+        del bad_observation['request']['configurations'][0]['target']['ra']
+        del bad_observation['request']['configurations'][0]['target']['dec']
+
+        response = self.client.post(reverse('api:schedule-list'), data=bad_observation)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('dec', str(response.content))
+
 
 class TestPostScheduleMultiConfigApi(SetTimeMixin, APITestCase):
     def setUp(self):

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -725,6 +725,12 @@ class RequestGroupSerializer(serializers.ModelSerializer):
         if data['observation_type'] == RequestGroup.DIRECT:
             # Don't do any time accounting stuff if it is a directly scheduled observation
             return data
+        else:
+            # for non-DIRECT observations, don't allow HOUR_ANGLE targets
+            for request in data['requests']:
+                for config in request['configurations']:
+                    if config['target']['type'] == 'HOUR_ANGLE':
+                        raise serializers.ValidationError(_('HOUR_ANGLE Target type not supported in scheduled observations'))
 
         try:
             total_duration_dict = get_total_duration_dict(data)

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -1114,17 +1114,11 @@ class TestHourAngleTarget(SetTimeMixin, APITestCase):
             'epoch': 2000
         }
 
-    def test_post_requestgroup_hour_angle_target(self):
-        good_data = self.generic_payload.copy()
-        response = self.client.post(reverse('api:request_groups-list'), data=good_data)
-        self.assertEqual(response.status_code, 201)
-
-    def test_post_requestgroup_hour_angle_missing_required_fields(self):
+    def test_post_requestgroup_hour_angle_target_fails(self):
         bad_data = self.generic_payload.copy()
-        del bad_data['requests'][0]['configurations'][0]['target']['dec']
         response = self.client.post(reverse('api:request_groups-list'), data=bad_data)
         self.assertEqual(response.status_code, 400)
-        self.assertIn('dec', str(response.content))
+        self.assertIn('HOUR_ANGLE Target type not supported', str(response.content))
 
 
 class TestLocationApi(SetTimeMixin, APITestCase):


### PR DESCRIPTION
… and disallow HOUR_ANGLE target types for non-direct submissions. 

If we think of any other validation restrictions we want to add we can add them to this pull request