### PR TITLE
Remove "ObservationPortalRequestLog" log messages

### DIFF
--- a/observation_portal/common/middleware.py
+++ b/observation_portal/common/middleware.py
@@ -6,46 +6,6 @@ from django.shortcuts import redirect
 from observation_portal.accounts.models import Profile
 
 
-class RequestLogMiddleware(object):
-    def __init__(self, get_response):
-        self.get_response = get_response
-        self.logger = logging.getLogger('observation_portal_request')
-
-    def __call__(self, request):
-        response = self.get_response(request)
-
-        try:
-            username = request.user.username
-            simple_interface = request.user.profile.simple_interface
-        except (AttributeError, Profile.DoesNotExist):
-            simple_interface = False
-            username = 'anonymous'
-
-        forwarded_ip = request.META.get('HTTP_X_FORWARDED_FOR')
-        if forwarded_ip:
-            ip_address = forwarded_ip.split(',')[0].strip()
-        else:
-            ip_address = request.META.get('REMOTE_ADDR')
-
-        tags = {
-            'ip_address': ip_address,
-            'uri': request.path,
-            'status': response.status_code,
-            'method': request.method,
-            'user': username,
-            'simple_interface': simple_interface,
-        }
-
-        if response.status_code >= 400:
-            level = logging.WARN
-        else:
-            level = logging.INFO
-
-        self.logger.log(level, 'ObservationPortalRequestLog', extra={'tags': tags})
-
-        return response
-
-
 class AcceptTermsMiddlware(object):
     def __init__(self, get_response):
         self.get_response = get_response

--- a/observation_portal/settings.py
+++ b/observation_portal/settings.py
@@ -75,7 +75,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'observation_portal.common.middleware.RequestLogMiddleware',
     'observation_portal.common.middleware.AcceptTermsMiddlware',
 ]
 


### PR DESCRIPTION
This application logs a bunch of lines which say
"ObservationPortalRequestLog" (and nothing else) over and over again.
This simply fills up the logging system's disk, without providing any
additional useful information (as far as I can tell).

Here is an example query showing all instances of this log message since
the current containers were started:

```
$ kubectl logs -l app.kubernetes.io/instance=observation-portal --all-containers --timestamps | grep ObservationPortalRequestLog
2019-07-17T22:18:15.786459777Z ObservationPortalRequestLog
2019-07-17T22:18:15.896831391Z ObservationPortalRequestLog
2019-07-17T22:18:16.267207083Z ObservationPortalRequestLog
2019-07-17T22:18:16.321665022Z ObservationPortalRequestLog
2019-07-17T22:18:17.158035736Z ObservationPortalRequestLog
2019-07-17T22:18:11.61618424Z ObservationPortalRequestLog
2019-07-17T22:18:13.392393172Z ObservationPortalRequestLog
2019-07-17T22:18:14.553258432Z ObservationPortalRequestLog
2019-07-17T22:18:16.568681714Z ObservationPortalRequestLog
2019-07-17T22:18:17.126812199Z ObservationPortalRequestLog
2019-07-17T22:18:15.128505218Z ObservationPortalRequestLog
2019-07-17T22:18:15.165644765Z ObservationPortalRequestLog
2019-07-17T22:18:16.819880902Z ObservationPortalRequestLog
2019-07-17T22:18:18.42285911Z ObservationPortalRequestLog
2019-07-17T22:18:19.03645736Z ObservationPortalRequestLog
2019-07-17T22:18:14.71166681Z ObservationPortalRequestLog
2019-07-17T22:18:17.651439984Z ObservationPortalRequestLog
2019-07-17T22:18:13.03176698Z ObservationPortalRequestLog
2019-07-17T22:18:14.256193229Z ObservationPortalRequestLog
2019-07-17T22:18:14.477296884Z ObservationPortalRequestLog
```

As far as I can tell, these logs aren't adding any value to the application. Since I couldn't figure out what they were for, I simply removed the code. This isn't honestly intended as a real fix, but I couldn't figure out what value these logs were supposed to be adding, either.