### PR TITLE
Set idle in transaction timeout

### DIFF
--- a/observation_portal/settings.py
+++ b/observation_portal/settings.py
@@ -103,6 +103,9 @@ WSGI_APPLICATION = 'observation_portal.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
+# https://www.postgresql.org/docs/9.6/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT
+PORTAL_IDLE_IN_TRANSACTION_TIMEOUT = 60 * 60 * 1000  # 1 hour
+
 DATABASES = {
    'default': {
        'ENGINE': os.getenv('DB_ENGINE', 'django.db.backends.postgresql'),
@@ -110,7 +113,10 @@ DATABASES = {
        'USER': os.getenv('DB_USER', 'postgres'),
        'PASSWORD': os.getenv('DB_PASSWORD', ''),
        'HOST': os.getenv('DB_HOST', '127.0.0.1'),
-       'PORT': os.getenv('DB_PORT', '5432')
+       'PORT': os.getenv('DB_PORT', '5432'),
+       'OPTIONS': {
+           'options': f'-c idle_in_transaction_session_timeout={PORTAL_IDLE_IN_TRANSACTION_TIMEOUT}'
+       }
    }
 }
 


### PR DESCRIPTION
I read through the [blog post](https://medium.com/squad-engineering/configure-postgres-statement-timeouts-from-within-django-6ce4cd33678a) describing how to set the timeout with a signal, but doing it that way did not feel quite right since I didn't find a clean way to reliably register that signal once (usually you register signals in each app, depending which one it goes with, but this would have needed to be registered once for the entire project on startup.)

After deciding that, I did a bit more digging and found that the parameter can be set in the settings file: https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-OPTIONS, and the backend options https://www.postgresql.org/docs/9.6/libpq-connect.html#LIBPQ-CONNECT-OPTIONS