### PR TITLE
Fix/optimization fixes

### DIFF
--- a/observation_portal/observations/admin.py
+++ b/observation_portal/observations/admin.py
@@ -31,8 +31,9 @@ class ConfigurationStatusAdmin(admin.ModelAdmin):
 
 
 class SummaryAdmin(admin.ModelAdmin):
-    list_display = ('start', 'end', 'state', 'reason', 'time_completed')
+    list_display = ('id', 'start', 'end', 'state', 'reason', 'time_completed')
     list_filter = ('state', )
+    raw_id_fields = ('configuration_status', )
 
 
 admin.site.register(Observation, ObservationAdmin)

--- a/observation_portal/observations/filters.py
+++ b/observation_portal/observations/filters.py
@@ -77,4 +77,4 @@ class ConfigurationStatusFilter(django_filters.FilterSet):
 
     class Meta:
         model = ConfigurationStatus
-        fields = '__all__'
+        fields = ('guide_camera_name',)

--- a/observation_portal/proposals/admin.py
+++ b/observation_portal/proposals/admin.py
@@ -91,10 +91,12 @@ class MembershipAdmin(admin.ModelAdmin):
 
 class ProposalInviteAdmin(admin.ModelAdmin):
     model = ProposalInvite
+    raw_id_fields = ['proposal']
 
 
 class ProposalNotificationAdmin(admin.ModelAdmin):
     model = ProposalNotification
+    raw_id_fields = ['proposal', 'user']
 
 
 admin.site.register(Semester, SemesterAdmin)

--- a/observation_portal/requestgroups/admin.py
+++ b/observation_portal/requestgroups/admin.py
@@ -64,6 +64,7 @@ class RequestGroupAdmin(admin.ModelAdmin):
     list_filter = ('state', 'created', 'modified')
     search_fields = ('name',)
     readonly_fields = ('requests', 'requests_count')
+    raw_id_fields = ('proposal', 'submitter')
 
     def requests_count(self, obj):
         return obj.requests.count()
@@ -106,6 +107,7 @@ class LocationAdmin(admin.ModelAdmin):
     )
     form = LocationForm
     list_filter = ('telescope_class',)
+    raw_id_fields = ('request',)
 
 
 class TargetAdmin(admin.ModelAdmin):
@@ -142,6 +144,7 @@ class TargetAdmin(admin.ModelAdmin):
         'dailymot',
         'epochofperih',
     )
+    raw_id_fields = ('configuration', )
     list_filter = ('type',)
     search_fields = ('name',)
 
@@ -178,6 +181,7 @@ class ConstraintsAdmin(admin.ModelAdmin):
         'max_seeing',
         'min_transparency',
     )
+    raw_id_fields = ('configuration',)
 
 
 class AcquisitionConfigAdmin(admin.ModelAdmin):
@@ -186,6 +190,7 @@ class AcquisitionConfigAdmin(admin.ModelAdmin):
         'configuration',
         'mode',
     )
+    raw_id_fields = ('configuration',)
 
 
 class GuidingConfigAdmin(admin.ModelAdmin):
@@ -196,6 +201,7 @@ class GuidingConfigAdmin(admin.ModelAdmin):
         'mode',
         'exposure_time'
     )
+    raw_id_fields = ('configuration',)
 
 
 admin.site.register(Constraints, ConstraintsAdmin)


### PR DESCRIPTION
The issue with the slow `/api/configurationstatus/` endpoint was its filter. For a filterset, if a field that is a foreign key is included, the default filter that is used is a [`ModelChoiceFilter`](https://django-filter.readthedocs.io/en/master/ref/filters.html#modelchoicefilter), which generates all the options for that field. So it's pretty slow on big tables.

The admin target change page was slow for a similar reason. The associated configuration is displayed on the page, and by default django will generate a dropdown with all options so that the user can update the associated configuration. Using [`raw_id_fields`](https://docs.djangoproject.com/en/2.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.raw_id_fields) helps that.