### PR TITLE
Add task for monthy time allocation reminders

### DIFF
--- a/observation_portal/proposals/models.py
+++ b/observation_portal/proposals/models.py
@@ -134,6 +134,18 @@ class Proposal(models.Model):
 
         logger.info('Users added to proposal {0}: {1}'.format(self, emails))
 
+    def send_time_allocation_reminder(self):
+        subject = _('Your LCO Time Allocation Summary')
+        message = render_to_string(
+            'proposals/timeallocationreminder.html',
+            {
+                'proposal': self,
+                'allocations': self.timeallocation_set.filter(semester=self.current_semester)
+            }
+        )
+
+        send_mail.send(subject, message, 'science-support@lco.global', [self.pi.email])
+
     def __str__(self):
         return self.id
 

--- a/observation_portal/proposals/models.py
+++ b/observation_portal/proposals/models.py
@@ -135,16 +135,19 @@ class Proposal(models.Model):
         logger.info('Users added to proposal {0}: {1}'.format(self, emails))
 
     def send_time_allocation_reminder(self):
-        subject = _('Your LCO Time Allocation Summary')
-        message = render_to_string(
-            'proposals/timeallocationreminder.html',
-            {
-                'proposal': self,
-                'allocations': self.timeallocation_set.filter(semester=self.current_semester)
-            }
-        )
+        if self.pi:
+            subject = _('Your LCO Time Allocation Summary')
+            message = render_to_string(
+                'proposals/timeallocationreminder.html',
+                {
+                    'proposal': self,
+                    'allocations': self.timeallocation_set.filter(semester=self.current_semester)
+                }
+            )
 
-        send_mail.send(subject, message, 'science-support@lco.global', [self.pi.email])
+            send_mail.send(subject, message, 'science-support@lco.global', [self.pi.email])
+        else:
+            logger.warn('Proposal {} does not have a PI!'.format(self))
 
     def __str__(self):
         return self.id

--- a/observation_portal/proposals/tasks.py
+++ b/observation_portal/proposals/tasks.py
@@ -1,0 +1,16 @@
+import dramatiq
+import logging
+
+from observation_portal.proposals.models import Proposal
+
+logger = logging.getLogger(__name__)
+
+
+@dramatiq.actor()
+def time_allocation_reminder():
+    for proposal in Proposal.current_proposals().filter(active=True):
+        if proposal.pi:
+            logger.info('Sending time allocation reminder for {}'.format(proposal))
+            proposal.send_time_allocation_reminder()
+        else:
+            logger.warn('Proposal {} does not have a PI!'.format(proposal))

--- a/observation_portal/proposals/tasks.py
+++ b/observation_portal/proposals/tasks.py
@@ -13,6 +13,6 @@ def time_allocation_reminder():
         # Only send an email if we are within 3 months of the end of the semester
         # and the proposal has at least one allocation.
         if (proposal.current_semester.end - timezone.now()).days <= 93 and \
-                proposal.timeallocation_set.count() > 0:
+                len(proposal.current_allocation) > 0:
             logger.info('Sending time allocation reminder for {}'.format(proposal))
             proposal.send_time_allocation_reminder()

--- a/observation_portal/proposals/tasks.py
+++ b/observation_portal/proposals/tasks.py
@@ -1,3 +1,4 @@
+from django.utils import timezone
 import dramatiq
 import logging
 
@@ -9,8 +10,9 @@ logger = logging.getLogger(__name__)
 @dramatiq.actor()
 def time_allocation_reminder():
     for proposal in Proposal.current_proposals().filter(active=True):
-        if proposal.pi:
+        # Only send an email if we are within 3 months of the end of the semester
+        # and the proposal has at least one allocation.
+        if (proposal.current_semester.end - timezone.now()).days <= 93 and \
+                proposal.timeallocation_set.count() > 0:
             logger.info('Sending time allocation reminder for {}'.format(proposal))
             proposal.send_time_allocation_reminder()
-        else:
-            logger.warn('Proposal {} does not have a PI!'.format(proposal))

--- a/observation_portal/proposals/templates/proposals/timeallocationreminder.html
+++ b/observation_portal/proposals/templates/proposals/timeallocationreminder.html
@@ -1,0 +1,50 @@
+{% load i18n %}
+<!doctype html>
+<html lang="en">
+
+<head>
+    <title>Time Allocation Notification</title>
+</head>
+
+<body>
+<p>
+Dear {{ proposal.pi.first_name}} {{ proposal.pi.last_name }},
+</p>
+
+<p>
+The following table shows your network time allocation and usage of {{ proposal }} so far (through {% now "F j, Y" %}) for
+{{ proposal.current_semester }}.  Note that the semester ends on
+{{ proposal.current_semester.end|date:"F j, Y" }}, and unused time does not carry over.
+Also, be aware that the end of the semester generally sees higher contention for observing resources.
+</p>
+
+<table cellpadding=10>
+  <thead>
+    <tr>
+      <th></th><th colspan="3">Hours Allocated</th><th colspan="3">Hours Used</th>
+    </tr>
+    <tr>
+      <th></th><th>Queue</th><th>Time Critical</th><th>Rapid Response</th>
+      <th>Queue</th><th>Time Critical</th><th>Rapid Response</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for ta in allocations %}
+    <tr>
+      <td>{{ ta.instrument_type }}</td>
+      <td>{{ ta.std_allocation }}</td>
+      <td>{{ ta.tc_allocation }}</td>
+      <td>{{ ta.rr_allocation }}</td>
+      <td>{{ ta.std_time_used|floatformat }}</td>
+      <td>{{ ta.tc_time_used|floatformat }}</td>
+      <td>{{ ta.rr_time_used|floatformat }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<p>
+Sincerely,<br/>
+LCO Science Support
+</p>
+</body>
+</html>

--- a/observation_portal/task_scheduler.py
+++ b/observation_portal/task_scheduler.py
@@ -4,6 +4,8 @@ from apscheduler.triggers.cron import CronTrigger
 from observation_portal.requestgroups.tasks import expire_requests
 from observation_portal.observations.tasks import delete_old_observations
 from observation_portal.accounts.tasks import expire_access_tokens
+from observation_portal.proposals.tasks import time_allocation_reminder
+
 
 def run():
     scheduler = BlockingScheduler()
@@ -19,5 +21,8 @@ def run():
         expire_access_tokens.send,
         CronTrigger.from_crontab('0 15 * * *')
     )
+    scheduler.add_job(
+        time_allocation_reminder.send,
+        CronTrigger.from_crontab('0 * 1 * *')  # monthly
+    )
     scheduler.start()
-

--- a/observation_portal/task_scheduler.py
+++ b/observation_portal/task_scheduler.py
@@ -23,6 +23,6 @@ def run():
     )
     scheduler.add_job(
         time_allocation_reminder.send,
-        CronTrigger.from_crontab('0 * 1 * *')  # monthly
+        CronTrigger.from_crontab('0 0 1 * *')  # monthly
     )
     scheduler.start()


### PR DESCRIPTION
Adds a task that, once a month, will send an email to every pi on a
current proposal with a summary of their allocated/used time. This is to
hopefully encourage users to use their time before it expires.