### PR TITLE
Fix/soar spectra config types

### DIFF
--- a/observation_portal/sciapplications/templates/sciapplications/index.html
+++ b/observation_portal/sciapplications/templates/sciapplications/index.html
@@ -107,7 +107,7 @@
                     <td>{{ app.status }}</td>
                     <td>
                         <a href="{% url 'sciapplications:detail' pk=app.id %}"><i class="fa fa-print"></i></a>
-                        <a href="{% url 'sciapplications:pdf' pk=app.id %}"><i class="fa fa-file-pdf-o"></i></a>
+                        <a href="{% url 'sciapplications:pdf' pk=app.id %}"><i class="far fa-file-pdf"></i></a>
                     </td>
                     <td><a href="{% url 'sciapplications:delete' pk=app.id %}" class="fa fa-trash" title="Delete draft"></a></td>
                 </tr>
@@ -146,7 +146,7 @@
                     <td>{{ app.status }}</td>
                     <td>
                         <a href="{% url 'sciapplications:detail' pk=app.id %}"><i class="fa fa-print"></i></a>
-                        <a href="{% url 'sciapplications:pdf' pk=app.id %}"><i class="fa fa-file-pdf-o"></i></a>
+                        <a href="{% url 'sciapplications:pdf' pk=app.id %}"><i class="far fa-file-pdf"></i></a>
                     </td>
                 </tr>
                 {% endif %}
@@ -186,7 +186,7 @@
                     <td>{{ app.status }}</td>
                     <td>
                         <a href="{% url 'sciapplications:detail' pk=app.id %}"><i class="fa fa-print"></i></a>
-                        <a href="{% url 'sciapplications:pdf' pk=app.id %}"><i class="fa fa-file-pdf-o"></i></a>
+                        <a href="{% url 'sciapplications:pdf' pk=app.id %}"><i class="far fa-file-pdf"></i></a>
                     </td>
                     <td><a href="{% url 'sciapplications:delete' pk=app.id %}" class="fa fa-trash" title="Delete draft"></a></td>
                 </tr>
@@ -217,7 +217,7 @@
                     <td>{{ app.status }}</td>
                     <td>
                         <a href="{% url 'sciapplications:detail' pk=app.id %}"><i class="fa fa-print"></i></a>
-                        <a href="{% url 'sciapplications:pdf' pk=app.id %}"><i class="fa fa-file-pdf-o"></i></a>
+                        <a href="{% url 'sciapplications:pdf' pk=app.id %}"><i class="far fa-file-pdf"></i></a>
                     </td>
                 </tr>
                 {% endif %}

--- a/static/js/components/configuration.vue
+++ b/static/js/components/configuration.vue
@@ -139,6 +139,8 @@
   </panel>
 </template>
 <script>
+  import _ from 'lodash';
+
   import { collapseMixin } from '../utils.js';
   import panel from './util/panel.vue';
   import customalert from './util/customalert.vue';
@@ -189,12 +191,12 @@
     },
     computed: {
       spectraConfigurationOptions: function() {
-        if (this.selectedinstrument) {
+        if (_.get(this.available_instruments, this.selectedinstrument, {}).type === 'SPECTRA') {
           if (this.selectedinstrument.includes('NRES')) {
             return [
               {value: 'NRES_SPECTRUM', 'text': 'Spectrum'}
             ]
-          } else if (this.selectedinstrument.includes('FLOYDS')) {
+          } else {
             return [
               {value: 'SPECTRUM', text: 'Spectrum'},
               {value: 'LAMP_FLAT', text: 'Lamp Flat'},


### PR DESCRIPTION
There were no configuration types returned for the soar spectrograph.

I also snuck an update to some icons that I noticed were broken.