### PR TITLE
Fix/fill window validation

### DIFF
--- a/observation_portal/requestgroups/duration_utils.py
+++ b/observation_portal/requestgroups/duration_utils.py
@@ -115,10 +115,11 @@ def get_request_duration_sum(requestgroup_dict):
 
 
 def get_num_exposures(instrument_config_dict, instrument_name,  time_available):
-    mol_duration_per_exp = get_instrument_configuration_duration_per_exposure(instrument_config_dict, instrument_name)
+    duration_per_exp = get_instrument_configuration_duration_per_exposure(instrument_config_dict, instrument_name)
     exposure_time = time_available.total_seconds()
-    num_exposures = exposure_time // mol_duration_per_exp
-
+    num_exposures = exposure_time // duration_per_exp
+    if exposure_time % duration_per_exp == 0:
+        num_exposures -= 1
     return max(1, num_exposures)
 
 

--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -571,12 +571,12 @@ class RequestSerializer(serializers.ModelSerializer):
             for configuration in data['configurations']:
                 for instrument_config in configuration['instrument_configs']:
                     if instrument_config.get('fill_window'):
-                        configuration_duration = get_instrument_configuration_duration(
+                        instrument_config_duration = get_instrument_configuration_duration(
                             instrument_config, configuration['instrument_type']
                         )
                         num_exposures = get_num_exposures(
                             instrument_config, configuration['instrument_type'],
-                            largest_interval - timedelta(seconds=duration - configuration_duration)
+                            largest_interval - timedelta(seconds=duration - instrument_config_duration)
                         )
                         instrument_config['exposure_count'] = num_exposures
                         duration = get_request_duration(data)

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -1615,14 +1615,16 @@ class TestConfigurationApi(SetTimeMixin, APITestCase):
         self.assertEqual(rg['requests'][0]['configurations'][0]['instrument_configs'][0]['exposure_count'], 5)
         self.assertEqual(response.status_code, 201)
 
-    @patch('observation_portal.requestgroups.serializers.get_largest_interval')
-    def test_fill_window_exposures_fit_exactly(self, mock_largest_interval):
-        # Will result in an exact number of exposures with overhead that fit into the available time
-        mock_largest_interval.return_value = timedelta(seconds=340)
-        n_exposures_fit_exactly = 5
+    def test_fill_window_when_exposures_fit_exactly(self):
         good_data = self.generic_payload.copy()
+        good_data['requests'][0]['windows'][0] = {
+            'start': '2016-09-29T23:12:00Z',
+            'end': '2016-09-29T23:21:30Z'
+        }
         good_data['requests'][0]['configurations'][0]['instrument_configs'][0]['exposure_time'] = 10
         good_data['requests'][0]['configurations'][0]['instrument_configs'][0]['fill_window'] = True
+        # The largest interval is 570s, available time is 460s, and instrument config duration is 46s
+        n_exposures_fit_exactly = 10
         response = self.client.post(reverse('api:request_groups-list'), data=good_data)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(


### PR DESCRIPTION
When fill_window is used in an instrument_config where the total number of exposures ends up being an exact number, validation ends up failing because the request duration must be less than the largest interval, not less than or equal to. This PR handles that edge case.