### PR TITLE
Set the AWS_LOCATION for s3boto3 to be the mediafiles dir

### DIFF
--- a/observation_portal/settings.py
+++ b/observation_portal/settings.py
@@ -197,6 +197,7 @@ AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID', None)
 AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY', None)
 AWS_S3_CUSTOM_DOMAIN = 's3-us-west-2.amazonaws.com/{}'.format(AWS_STORAGE_BUCKET_NAME)
 AWS_IS_GZIPPED = True
+AWS_LOCATION = os.getenv('AWS_LOCATION', 'media')
 AWS_DEFAULT_ACL = None
 
 STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]

--- a/observation_portal/settings.py
+++ b/observation_portal/settings.py
@@ -197,7 +197,7 @@ AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID', None)
 AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY', None)
 AWS_S3_CUSTOM_DOMAIN = 's3-us-west-2.amazonaws.com/{}'.format(AWS_STORAGE_BUCKET_NAME)
 AWS_IS_GZIPPED = True
-AWS_LOCATION = os.getenv('AWS_LOCATION', 'media')
+AWS_LOCATION = os.getenv('MEDIAFILES_DIR', 'media')
 AWS_DEFAULT_ACL = None
 
 STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]


### PR DESCRIPTION
This is what was forgotten when we did away with the split_storage.py and static AWS storage. I think just setting this to the mediafiles dir will make the mediafiles be saved and loaded from that dir in the S3 bucket.