### PR TITLE
Handle if a mode is not passed in

### DIFF
--- a/observation_portal/observations/serializers.py
+++ b/observation_portal/observations/serializers.py
@@ -190,8 +190,10 @@ class ScheduleSerializer(serializers.ModelSerializer):
 
             # Also check the guide and acquisition cameras are valid if specified
             # But only if the guide mode is set
-            if (configuration['guiding_config']['mode'] != GuidingConfig.OFF or
-                    configuration['acquisition_config']['mode'] != AcquisitionConfig.OFF):
+            if (
+                    configuration['guiding_config'].get('mode', GuidingConfig.OFF) != GuidingConfig.OFF or
+                    configuration['acquisition_config'].get('mode', AcquisitionConfig.OFF) != AcquisitionConfig.OFF
+            ):
                 if not configuration.get('guide_camera_name', ''):
                     if (
                         'extra_params' in configuration


### PR DESCRIPTION
Handles case where a direct submission does not have a mode set for the guiding_config and/or acquisition_config so that we do not crash.