### PR TITLE
Fix/many proposal invites

### DIFF
--- a/observation_portal/accounts/forms.py
+++ b/observation_portal/accounts/forms.py
@@ -39,8 +39,14 @@ class CustomRegistrationForm(RegistrationFormTermsOfService, RegistrationFormUni
             view_authored_requests_only=self.cleaned_data['education_user'],
             simple_interface=self.cleaned_data['education_user']
         )
-        for invite in ProposalInvite.objects.filter(email__iexact=new_user_instance.email):
-            invite.accept(new_user_instance)
+        # There may be more than one proposal invite for the same proposal for the same user. Use the latest invite
+        # that was sent if this is the case.
+        proposal_invites = {}
+        for proposal_invite in ProposalInvite.objects.filter(email__iexact=new_user_instance.email).order_by('sent'):
+            proposal_invites[proposal_invite.proposal.id] = proposal_invite
+
+        for proposal_id in proposal_invites:
+            proposal_invites[proposal_id].accept(new_user_instance)
 
         return new_user_instance
 

--- a/observation_portal/proposals/test_views.py
+++ b/observation_portal/proposals/test_views.py
@@ -210,6 +210,17 @@ class TestProposalInvite(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Please enter a valid email address')
 
+    def test_pi_cannot_invite_themselves_as_coi(self):
+        self.client.force_login(self.pi_user)
+        response = self.client.post(
+            reverse('proposals:invite', kwargs={'pk': self.proposal.id}),
+            data={'email': self.pi_user.email},
+            follow=True
+        )
+        self.assertFalse(ProposalInvite.objects.filter(email=self.pi_user.email, proposal=self.proposal).exists())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'You cannot invite yourself ({self.pi_user.email}) to be a Co-Investigator')
+
 
 class TestProposalList(TestCase):
     def setUp(self):

--- a/observation_portal/proposals/views.py
+++ b/observation_portal/proposals/views.py
@@ -115,7 +115,10 @@ class InviteCreateView(LoginRequiredMixin, View):
                 validate_email(email)
             except ValidationError:
                 valid = False
-                messages.error(request, _('Please enter a valid email address: {}'.format(email)))
+                messages.error(request, _(f'Please enter a valid email address: {email}'))
+            if email.lower() == request.user.email.lower():
+                messages.error(request, f'You cannot invite yourself ({email}) to be a Co-Investigator')
+                valid = False
         if valid:
             proposal.add_users(emails, Membership.CI)
             messages.success(request, _('Co Investigator(s) invited'))


### PR DESCRIPTION
There are two fixes in this PR:
1) In a proposal detail view, a PI is able to invite users to be CoIs. These changes stop the PI from inviting themself to be a CoI.
2) Handle the case where there is more than one proposal invite for the same email and proposal. When this happens, use the most recent invitation. 