### PR TITLE
Save observations and configuration statuses together

### DIFF
--- a/observation_portal/observations/serializers.py
+++ b/observation_portal/observations/serializers.py
@@ -243,7 +243,7 @@ class ScheduleSerializer(serializers.ModelSerializer):
             rg = rgs.save()
 
             observation = Observation.objects.create(request=rg.requests.first(), **obs_fields)
-            
+
             for i, config in enumerate(rg.requests.first().configurations.all()):
                 ConfigurationStatus.objects.create(
                     configuration=config,

--- a/observation_portal/observations/serializers.py
+++ b/observation_portal/observations/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from django.utils import timezone
+from django.db import transaction
 from django.utils.translation import ugettext as _
 
 from observation_portal.common.configdb import configdb
@@ -236,17 +237,20 @@ class ScheduleSerializer(serializers.ModelSerializer):
             del configuration['instrument_name']
             del configuration['guide_camera_name']
 
-        rgs = ObserveRequestGroupSerializer(data=validated_data, context=self.context)
-        rgs.is_valid(True)
-        rg = rgs.save()
+        with transaction.atomic():
+            rgs = ObserveRequestGroupSerializer(data=validated_data, context=self.context)
+            rgs.is_valid(True)
+            rg = rgs.save()
 
-        observation = Observation.objects.create(request=rg.requests.first(), **obs_fields)
-
-        for i, config in enumerate(rg.requests.first().configurations.all()):
-            ConfigurationStatus.objects.create(configuration=config, observation=observation,
-                                               instrument_name=config_instrument_names[i][0],
-                                               guide_camera_name=config_instrument_names[i][1])
-
+            observation = Observation.objects.create(request=rg.requests.first(), **obs_fields)
+            
+            for i, config in enumerate(rg.requests.first().configurations.all()):
+                ConfigurationStatus.objects.create(
+                    configuration=config,
+                    observation=observation,
+                    instrument_name=config_instrument_names[i][0],
+                    guide_camera_name=config_instrument_names[i][1]
+                )
         return observation
 
     def to_representation(self, instance):
@@ -292,7 +296,10 @@ class ObservationSerializer(serializers.ModelSerializer):
                 break
 
         if not in_a_window:
-            raise serializers.ValidationError(_('The start {} and end {} times do not fall within any window of the request'.format(data['start'].isoformat(), data['end'].isoformat())))
+            raise serializers.ValidationError(_(
+                'The start {} and end {} times do not fall within any window of the request'.format(
+                    data['start'].isoformat(), data['end'].isoformat())
+            ))
 
         # Validate that the site, enclosure, and telescope match the location of the request
         if (
@@ -325,10 +332,10 @@ class ObservationSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         configuration_statuses = validated_data.pop('configuration_statuses')
-        observation = Observation.objects.create(**validated_data)
-        for configuration_status in configuration_statuses:
-            ConfigurationStatus.objects.create(observation=observation, **configuration_status)
-
+        with transaction.atomic():
+            observation = Observation.objects.create(**validated_data)
+            for configuration_status in configuration_statuses:
+                ConfigurationStatus.objects.create(observation=observation, **configuration_status)
         return observation
 
 


### PR DESCRIPTION
There was an error while serializing the response for a GET request to `/api/schedule/`. The error was a KeyError that was raised in the `as_dict` method of an Observation [here](https://github.com/LCOGT/observation-portal/blob/master/observation_portal/observations/models.py#L114), which suggests that a configuration status did not exist for one of the observation's configurations at the time of the method call.

The time of the error corresponds with the creation time of the observation in question- The observation was created at UT 9/8 05:34:00 and the timestamp in the error email is UT 9/8 05:34:05.

I've wrapped observation creation in a transaction so that an Observation will not be included in a queryset until both it and its config statuses have been saved. In the ScheduleSerializer save method, I included saving the request group in the transaction as well since I figure that if there is an error creating the observation, we probably don't want to keep the requestgroup around... Let me know what you think about that, especially given the work that you've been doing on your deadlock fixes branch.