### PR TITLE
mark request as complete if all configuration statuses are complete, …

### DIFF
--- a/observation_portal/requestgroups/request_utils.py
+++ b/observation_portal/requestgroups/request_utils.py
@@ -118,10 +118,10 @@ def get_airmasses_for_request_at_sites(request_dict, is_staff=False):
     return data
 
 
-def exposure_completion_percentage(observation):
+def exposure_completion_percentage(configuration_statuses):
     total_exposure_time = 0
     completed_exposure_time = 0
-    for configuration_status in observation.configuration_statuses.all():
+    for configuration_status in configuration_statuses:
         if hasattr(configuration_status, 'summary'):
             completed_exposure_time += configuration_status.summary.time_completed
         configuration_exposure_time = 0


### PR DESCRIPTION
…even if time_completed is off.

Nikolaus mentioned there was an issue with the autofocus requests during the night completing but getting rescheduled and this is why. I think in valhalla we used to take molecule completion first, and fallback on time/exposures complete if the molecule wasn't marked as completed, so this should restore that behaviour. This means things like auto focus and other script type observations will mark their request as complete if the site software reports the configuration as complete, since their time completed will never be correct