### PR TITLE
Fix/proposal semester page 2

### DIFF
--- a/observation_portal/proposals/templates/proposals/semester_detail.html
+++ b/observation_portal/proposals/templates/proposals/semester_detail.html
@@ -27,7 +27,6 @@
           <col style="width: 5%">
           <col style="width: 5%">
           <col style="width: 5%">
-          <col style="width: 5%">
         </colgroup>
         <thead><tr>
           <th>PI Name</th>
@@ -39,7 +38,6 @@
           <th>NRES (1m)</th>
           <th>Sinistro (1m)</th>
           <th>SBIG (0.4m)</th>
-          <th>SBIG (2.0m)</th>
           <th>GHTS REDCAM (4.0m)</th>
           <th>GHTS REDCAM IMAGER (4.0m)</th>
         </tr></thead>
@@ -70,9 +68,6 @@
             </td>
             <td>
               {{ proposal.current_allocation.0M4SCICAMSBIG.std|floatformat:0 }}
-            </td>
-            <td>
-              {{ proposal.current_allocation.2M0SCICAMSBIG.std|floatformat:0 }}
             </td>
             <td>
               {{ proposal.current_allocation.SOAR_GHTS_REDCAM.std|floatformat:0 }}

--- a/static/js/components/target.vue
+++ b/static/js/components/target.vue
@@ -143,6 +143,7 @@
                 label="Orbital Inclination"
                 field="orbinc"
                 :errors="errors.orbinc"
+                desc="Angle in Degrees"
                 @input="update"
               />
               <customfield


### PR DESCRIPTION
This is another small update to the semester proposal page, removing the 2m SBIG column as requested. I also snuck in some help text for orbital inclination on the compose page.