### PR TITLE
Feature/observation page updates

### DIFF
--- a/observation_portal/observations/filters.py
+++ b/observation_portal/observations/filters.py
@@ -11,38 +11,38 @@ class ObservationFilter(mixins.CustomIsoDateTimeFilterMixin, django_filters.Filt
     site = django_filters.MultipleChoiceFilter(choices=configdb.get_site_tuples())
     enclosure = django_filters.MultipleChoiceFilter(choices=configdb.get_enclosure_tuples())
     telescope = django_filters.MultipleChoiceFilter(choices=configdb.get_telescope_tuples())
-    start_after = django_filters.IsoDateTimeFilter(
-        field_name='start',
-        lookup_expr='gte',
-        label='Start after',
-        widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
-    )
     time_span = django_filters.DateRangeFilter(
         field_name='start',
         label='Time Span'
     )
+    start_after = django_filters.IsoDateTimeFilter(
+        field_name='start',
+        lookup_expr='gte',
+        label='Start After (Inclusive)',
+        widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
+    )
     start_before = django_filters.IsoDateTimeFilter(
         field_name='start',
         lookup_expr='lt',
-        label='Start before',
+        label='Start Before',
         widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
     )
     end_after = django_filters.IsoDateTimeFilter(
         field_name='end',
         lookup_expr='gte',
-        label='End after',
+        label='End After (Inclusive)',
         widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
     )
     end_before = django_filters.IsoDateTimeFilter(
         field_name='end',
         lookup_expr='lt',
-        label='End before',
+        label='End Before',
         widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
     )
     modified_after = django_filters.IsoDateTimeFilter(
         field_name='modified',
         lookup_expr='gte',
-        label='Modified After',
+        label='Modified After (Inclusive)',
         widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
     )
     request_id = django_filters.CharFilter(field_name='request__id')

--- a/observation_portal/observations/filters.py
+++ b/observation_portal/observations/filters.py
@@ -8,9 +8,9 @@ from observation_portal.common import mixins
 
 
 class ObservationFilter(mixins.CustomIsoDateTimeFilterMixin, django_filters.FilterSet):
-    site = django_filters.MultipleChoiceFilter(choices=configdb.get_site_tuples())
-    enclosure = django_filters.MultipleChoiceFilter(choices=configdb.get_enclosure_tuples())
-    telescope = django_filters.MultipleChoiceFilter(choices=configdb.get_telescope_tuples())
+    site = django_filters.MultipleChoiceFilter(choices=sorted(configdb.get_site_tuples()))
+    enclosure = django_filters.MultipleChoiceFilter(choices=sorted(configdb.get_enclosure_tuples()))
+    telescope = django_filters.MultipleChoiceFilter(choices=sorted(configdb.get_telescope_tuples()))
     time_span = django_filters.DateRangeFilter(
         field_name='start',
         label='Time Span'
@@ -60,12 +60,12 @@ class ObservationFilter(mixins.CustomIsoDateTimeFilterMixin, django_filters.Filt
     )
     proposal = django_filters.CharFilter(field_name='request__request_group__proposal__id', label='Proposal')
     instrument_type = django_filters.MultipleChoiceFilter(
-        choices=configdb.get_instrument_type_tuples(),
+        choices=sorted(configdb.get_instrument_type_tuples()),
         label='Instrument Type',
         field_name='configuration_statuses__configuration__instrument_type'
     )
     configuration_type = django_filters.MultipleChoiceFilter(
-        choices=configdb.get_configuration_type_tuples(),
+        choices=sorted(configdb.get_configuration_type_tuples()),
         label='Configuration Type',
         field_name='configuration_statuses__configuration__type'
     )

--- a/observation_portal/observations/filters.py
+++ b/observation_portal/observations/filters.py
@@ -17,6 +17,10 @@ class ObservationFilter(mixins.CustomIsoDateTimeFilterMixin, django_filters.Filt
         label='Start after',
         widget=forms.TextInput(attrs={'class': 'input', 'type': 'date'})
     )
+    time_span = django_filters.DateRangeFilter(
+        field_name='start',
+        label='Time Span'
+    )
     start_before = django_filters.IsoDateTimeFilter(
         field_name='start',
         lookup_expr='lt',

--- a/observation_portal/observations/templates/observations/observation_list.html
+++ b/observation_portal/observations/templates/observations/observation_list.html
@@ -74,6 +74,7 @@
   </div>
   <div class="col-md-2">
     <form class="form" method="GET" action="{% url 'observations:observation-list' %}">
+    {% buttons submit="Filter" reset="Reset" %}{% endbuttons %}
     {% bootstrap_form filter.form exclude="end_after,end_before" %}
     {% buttons submit="Filter" reset="Reset" %}{% endbuttons %}
     </form>


### PR DESCRIPTION
Some usability updates.
- Second set of filter buttons at top of filters for less scrolling
- Filter for common time ranges
- Sort options that show up in select boxes. I ended up sorting the options in the filterset itself because the list size is so small that the added sort doesn't really matter much, and then the options will appear sorted in both the observations page and in the browseable api. 