### PR TITLE
Add validation to make sure there is at least one instrument configuration

### DIFF
--- a/observation_portal/requestgroups/serializers.py
+++ b/observation_portal/requestgroups/serializers.py
@@ -236,6 +236,8 @@ class ConfigurationSerializer(serializers.ModelSerializer):
     def validate_instrument_configs(self, value):
         if len(set([instrument_config.get('rotator_mode', '') for instrument_config in value])) > 1:
             raise serializers.ValidationError(_('Rotator modes within the same configuration must be the same'))
+        if len(value) < 1:
+            raise serializers.ValidationError(_('A configuration must have at least one instrument configuration'))
         return value
 
     def validate_instrument_type(self, value):

--- a/observation_portal/requestgroups/test/test_api.py
+++ b/observation_portal/requestgroups/test/test_api.py
@@ -1287,6 +1287,13 @@ class TestConfigurationApi(SetTimeMixin, APITestCase):
         self.generic_payload['proposal'] = self.proposal.id
         self.extra_configuration = copy.deepcopy(self.generic_payload['requests'][0]['configurations'][0])
 
+    def test_must_have_at_least_one_instrument_config(self):
+        bad_data = self.generic_payload.copy()
+        bad_data['requests'][0]['configurations'][0]['instrument_configs'] = []
+        response = self.client.post(reverse('api:request_groups-list'), data=bad_data)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('must have at least one instrument configuration', str(response.content))
+
     def test_default_guide_mode_for_spectrograph(self):
         good_data = self.generic_payload.copy()
         response = self.client.post(reverse('api:request_groups-list'), data=good_data)


### PR DESCRIPTION
Recently some requests were submitted that did not have any instrument configurations. There are certain cases, like for SCRIPT type configurations, where maybe no instrument configs are needed However, generally a configuration needs at least one instrument config to make sense. Also, the site did not handle getting these observations in the schedule very well. This PR validates a requestgroup to make sure there is at least one instrument config.