### PR TITLE
Update getting started guide links

### DIFF
--- a/observation_portal/sciapplications/templates/sciapplications/index.html
+++ b/observation_portal/sciapplications/templates/sciapplications/index.html
@@ -26,7 +26,7 @@
             If you are composing a proposal for the LCO network for the first time, we recommend that you consult our <a href="https://lco.global/observatory/proposal/guidelines/">guidelines for writing proposals,</a> as well as the <a href="https://lco.global/documents/450/GettingStartedontheLCONetwork.latest.pdf">"Getting Started" Guide.</a>
             Information about the <a href="http://lcogt.net/observatory/telescopes">telescopes</a>, <a href="http://lcogt.net/observatory/instruments">instruments</a>,
             <a href="http://lcogt.net/observatory/data">data handling and quality</a>, <a href="http://lcogt.net/observatory/scheduling">scheduling</a>
-            and other technical aspects of the network is available on the <a href="http://lcogt.net/observatory/capabilities">observatory capabilities</a> pages.
+            and other technical aspects of the network is available on the <a href="https://lco.global/observatory/">observatory capabilities</a> pages.
         </p>
 
         <table class="table">

--- a/observation_portal/sciapplications/templates/sciapplications/index.html
+++ b/observation_portal/sciapplications/templates/sciapplications/index.html
@@ -23,7 +23,7 @@
             Please refer to the LCO website for more information on the <a href="https://lco.global/observatory/proposal/process/">time allocation process.</a>
         </p>
         <p>
-            If you are composing a proposal for the LCO network for the first time, we recommend that you consult our <a href="https://lco.global/observatory/proposal/guidelines/">guidelines for writing proposals,</a> as well as the <a href="https://lco.global/files/User_Documentation/gettingstartedonthelconetwork.latest.pdf">"Getting Started" Guide.</a>
+            If you are composing a proposal for the LCO network for the first time, we recommend that you consult our <a href="https://lco.global/observatory/proposal/guidelines/">guidelines for writing proposals,</a> as well as the <a href="https://lco.global/documents/450/GettingStartedontheLCONetwork.latest.pdf">"Getting Started" Guide.</a>
             Information about the <a href="http://lcogt.net/observatory/telescopes">telescopes</a>, <a href="http://lcogt.net/observatory/instruments">instruments</a>,
             <a href="http://lcogt.net/observatory/data">data handling and quality</a>, <a href="http://lcogt.net/observatory/scheduling">scheduling</a>
             and other technical aspects of the network is available on the <a href="http://lcogt.net/observatory/capabilities">observatory capabilities</a> pages.

--- a/templates/help.html
+++ b/templates/help.html
@@ -27,7 +27,7 @@
             </li>
         </ul>
 
-        <p>If you are a new user of this Observation Portal, we strongly recommend that you read the <a href="https://lco.global/documents/55/GettingStartedontheLCONetwork.latest.pdf">"Getting Started on the LCO Global Telescope Network" Guide.</a>
+        <p>If you are a new user of this Observation Portal, we strongly recommend that you read the <a href="https://lco.global/documents/450/GettingStartedontheLCONetwork.latest.pdf">"Getting Started on the LCO Global Telescope Network" Guide.</a>
         </p>
         <p>If you are a new user of the LCO network, information about the <a href="https://lco.global/observatory/telescopes">telescopes</a>,
            <a href="https://lco.global/observatory/instruments">instruments</a>, <a href="http://lcogt.net/observatory/data">data handling and quality</a>,


### PR DESCRIPTION
I've updated the getting started guide links as requested. The "observatory capabilities" link on the `/apply/` page is also broken, please let me know where you would like that to go.