### PR TITLE
Check that a proposal has time allocations in the current semester before sending email

### DIFF
--- a/observation_portal/proposals/tasks.py
+++ b/observation_portal/proposals/tasks.py
@@ -12,7 +12,9 @@ def time_allocation_reminder():
     for proposal in Proposal.current_proposals().filter(active=True).distinct():
         # Only send an email if we are within 3 months of the end of the semester
         # and the proposal has at least one allocation.
-        if (proposal.current_semester.end - timezone.now()).days <= 93 and \
-                len(proposal.current_allocation) > 0:
+        if (
+                len(proposal.current_allocation) > 0
+                and (proposal.current_semester.end - timezone.now()).days <= 93
+        ):
             logger.info('Sending time allocation reminder for {}'.format(proposal))
             proposal.send_time_allocation_reminder()


### PR DESCRIPTION
Background information: Summary emails are sent out to PIs once per month within 3 months of the end of the semester to let them know how much of their allocated time has been used. The intention is to only send out the summary emails to PIs of active proposals that have time allocations in the current semester.

However, the way that the `if` statement was written, it would first check if we were within 3 months, and then it would check if there were current time allocations. This code crashes when there are no time allocations in the current semester because the first check required the second to be true as `proposal.current_semester` is `None` if there are no allocations in the current semester. 

Switching the order of the checks fixes the problem. I added some tests to make sure.