### PR TITLE
fix the rise_set calculation to use site details for the correct clas…

### DIFF
--- a/observation_portal/common/rise_set_utils.py
+++ b/observation_portal/common/rise_set_utils.py
@@ -40,7 +40,9 @@ def get_rise_set_intervals_by_site(request: dict) -> dict:
     Returns:
         rise_set intervals by site
     """
-    site_details = configdb.get_sites_with_instrument_type_and_location()
+    site_details = configdb.get_sites_with_instrument_type_and_location(
+        instrument_type=request['configurations'][0]['instrument_type']
+    )
     intervals_by_site = {}
     for site in site_details:
         intervals_by_site[site] = None


### PR DESCRIPTION
…s of telescope based on instrument type

This is a fix for: https://lcoglobal.redmineup.com/issues/1193

I'm not sure how we missed this all this time, but before this fix, it just returns the 'first' telescope at a sites details, which may have different horizon/ha_limit values if there are 2m, 1m, and 0m4 at that site.